### PR TITLE
Remove explicit names() calls in granovagg.ds InitializeGgplot

### DIFF
--- a/R/granovagg.ds.R
+++ b/R/granovagg.ds.R
@@ -342,12 +342,13 @@ granovagg.ds <- function(data       = NULL,
 
   
   InitializeGgplot <- function(dsp) {
-    return(ggplot(aes_string(x = names(dsp$data)[1], 
-                             y = names(dsp$data)[2]
-                            ),
-                  data = dsp$data
-                 )
-          )
+    return(
+      ggplot(
+        aes_string(x = dsp$data[1], 
+                   y = dsp$data[2]
+        ), data = dsp$data
+      )
+    )
   }
     
   TreatmentLine <- function(dsp) {


### PR DESCRIPTION
@rmpruzek [points out](https://github.com/briandk/granovaGG/pull/128#issuecomment-2334678) that when `granovagg.ds` is passed data where the column names have more than one word, there is a text-parsing error:

``` r
> set.seed(1001)
> test.data <- data.frame(x = rnorm(12), y = rnorm(12))
> colnames(test.data) <- c("Word One", "Word Two")
> granovagg.ds(test.data)
                              Summary Statistics
n                                         12.000
Word One mean                             -0.123
Word Two mean                              0.321
mean(D = Word One - Word Two)             -0.444
SD(D)                                      1.788
Effect Size                               -0.248
r(Word One, Word Two)                     -0.170
r(Word One + Word Two, D)                  0.262
Lower 95% Confidence Interval             -1.580
Upper 95% Confidence Interval              0.692
t (D-bar)                                 -0.861
df.t                                      11.000
p-value (t-statistic)                      0.408
Error in parse(text = x) : <text>:1:6: unexpected symbol
1: Word One
        ^
```

The proposed patch should fix that error. 
