### PR TITLE
Granovagg1w jitter interferes with overplotting logic

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: granovaGG
-Version: 1.0.20111012175407
+Version: 1.0.20111012184651
 Date: 2011-09-03
 Title: Graphical Analysis of Variance Using ggplot2
 Author: Brian A. Danielak <brian@briandk.com>, 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: granovaGG
-Version: 1.0.20111012184651
+Version: 1.0.20111012185037
 Date: 2011-09-03
 Title: Graphical Analysis of Variance Using ggplot2
 Author: Brian A. Danielak <brian@briandk.com>, 

--- a/R/granovagg.1w.R
+++ b/R/granovagg.1w.R
@@ -105,7 +105,7 @@ granovagg.1w <- function(data,
                          group         = NULL, 
                          h.rng         = 1, 
                          v.rng         = 1,
-                         jj            = NULL,
+                         jj            = 1,
                          dg            = 2, 
                          resid         = FALSE,
                          print.squares = TRUE,  
@@ -411,12 +411,9 @@ granovagg.1w <- function(data,
   }
 
   GetDegreeOfJitter <- function(owp) {
-    result <- owp$params$horizontal.percent
+    result <- (jj / 200) * owp$params$contrast.range.distance
     
-    if (!is.null(jj)) {
-      result <- (jj / 200) * owp$params$contrast.range.distance
-    } 
-    else if (IsSmallestContrastDifferenceSmallerThanOnePercentOfDataResolution(owp)) {
+    if (IsSmallestContrastDifferenceSmallerThanOnePercentOfDataResolution(owp)) {
         result <- GetSmallestDistanceBetweenAdjacentContrasts(owp$summary$contrast)
     }
     

--- a/R/granovagg.1w.R
+++ b/R/granovagg.1w.R
@@ -411,7 +411,7 @@ granovagg.1w <- function(data,
   }
 
   GetDegreeOfJitter <- function(owp) {
-    result <- (jj / 200) * owp$params$contrast.range.distance
+    result <- jj * owp$params$horizontal.percent
     
     if (IsSmallestContrastDifferenceSmallerThanOnePercentOfDataResolution(owp)) {
         result <- GetSmallestDistanceBetweenAdjacentContrasts(owp$summary$contrast)


### PR DESCRIPTION
The default value for jitter (`jj`) in `granova.1w` was `1`:

``` r
granova.1w(data, group = NULL, dg = 2, h.rng = 1.25, v.rng = 0.2, 
   box = FALSE, jj = 1, kx = 1, px = 1, size.line = -2.5, 
   top.dot = 0.15, trmean = FALSE, resid = FALSE, dosqrs = TRUE, 
   ident = FALSE, pt.lab = NULL, xlab = NULL, ylab = NULL, 
   main = NULL, ...)
```

For `granovagg.1w`, [we introduced overplotting logic](https://github.com/briandk/granovaGG/commit/ad39a745c07a94be8db046a978994cddb657dbef) that would recalibrate jitter if groups were too close together. The idea was to protect the user: if groups were too close together, the jittering amount would be very conservative so adjacently plotted groups could still be individually resolved. But, introducing that logic involved a key departure from the classic `granova.1w` API. With the new overplotting logic:
- The default value of `jj` was set to `NULL`
- if `jj == NULL`, the jitter amount defaulted to one percent of the horizontal resolution of the data, UNLESS `jj == NULL` _and_ at least one pair of means was in danger of overplotting. If there was overplotting danger when `jj` was set to `NULL`, the jitter amount would default to the smallest distance between adjacent contrasts.

If we want change the default value of jj to 1, I fear we'll have to go one of two routes:
1. Remove the jittering overplotting logic entirely.
2. Keep the overplotting logic, but conditionally ignore any user-supplied `jj` values if the group means are in danger of overplotting.
3. Keep the jittering overplotting logic, but add a new parameter to `granovagg.1w` called something like `safe.jittering` that would turn the overplotting logic on or off, thus allowing the user to bypass overplotting protection.

Option 1 is simple and possible. Combined with our current logic for marking likely overplotted groups in red, it lets the user simply tweak and shrink jittering until they can safely resolve groups. But it's risky if users don't recognize when their data is overplotted.

Option 2 strikes me as undesirable: it gives users the illusion of having control over jittering when really we can be like overprotective parents and override their supplied value if we think it's too dangerous.

Option 3 is kludgy, inelegant, and adds an additional burden to the user for remembering parameters.

I need both @rmpruzek and @wildoane to weigh in on this issue before I can go forward with any changes.
