### PR TITLE
We should use more robust Math typesetting

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: granovaGG
-Version: 1.1.20120816163436
+Version: 1.1.20120831111253
 Date: 2012-02-23
 Title: Graphical Analysis of Variance Using ggplot2
 Author: Brian A. Danielak <brian@briandk.com>,

--- a/R/granovagg.1w.R
+++ b/R/granovagg.1w.R
@@ -14,7 +14,7 @@
 #' the one-way F statistic, the mean square between (MS.B), is a linear combination
 #' of the group means; each weight -- one for each group -- in the L.C. is (principally)
 #' a function of the difference between the group's mean and the grand
-#' mean, viz., (M_{j} - M..) where M_{j} denotes the jth group's mean, and M.. denotes
+#' mean, viz., \eqn{M_j} (M_{j} - M..) where M_{j} denotes the jth group's mean, and M.. denotes
 #' the grand mean. The L.C. can be written as a sum of products of the form
 #' MS.B = Sum((1/df.B)(n_j (M_j - M..) M_j)) for j = 1...J.
 #' The denominator of the F-statistic, MS.W

--- a/man/granovagg.1w.Rd
+++ b/man/granovagg.1w.Rd
@@ -98,10 +98,10 @@
   linear combination of the group means; each weight -- one
   for each group -- in the L.C. is (principally) a function
   of the difference between the group's mean and the grand
-  mean, viz., (M_{j} - M..) where M_{j} denotes the jth
-  group's mean, and M.. denotes the grand mean. The L.C.
-  can be written as a sum of products of the form MS.B =
-  Sum((1/df.B)(n_j (M_j - M..) M_j)) for j = 1...J. The
+  mean, viz., \eqn{M_j} (M_{j} - M..) where M_{j} denotes
+  the jth group's mean, and M.. denotes the grand mean. The
+  L.C. can be written as a sum of products of the form MS.B
+  = Sum((1/df.B)(n_j (M_j - M..) M_j)) for j = 1...J. The
   denominator of the F-statistic, MS.W (mean square
   within), can be described as a 'scaling factor'. It is
   just the (weighted) average of the variances of the J


### PR DESCRIPTION
Inline math can be formatted with `\eqn{}`

"block" equation displays can be wrapped in `\deqn{}`
